### PR TITLE
Install webpack@4 with npm install

### DIFF
--- a/posts/guides/v3/01-getting-started.md
+++ b/posts/guides/v3/01-getting-started.md
@@ -31,7 +31,7 @@ mkdir my-blog  && cd my-blog  && npm init -y
 For our first project we will need, at least, to install **Nextein**, **Next.js** and **React**. You can add more dependencies as you need them later.
 
 ```bash
-npm install --save next react react-dom nextein
+npm install --save next react react-dom nextein webpack@4
 ```
 ## Create Your First Page and Post
 


### PR DESCRIPTION
As mentioned in https://github.com/elmasse/nextein/issues/328, the next.js update appears to have broken things. Installing webpack manually in the `npm install` step doesn't work either for me unless I pin it to major version 4.